### PR TITLE
set the default service to ClusterIP

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -59,6 +59,6 @@ master:
     NUMBER_OF_MASTERS: "2"
 
 service:
-  type: LoadBalancer
+  type: ClusterIP
   httpPort: 9200
   transportPort: 9300


### PR DESCRIPTION
ES cluster are in general only accessible internally.
Use it as a more default secure configuration.