### PR TITLE
Fix Kibana Elasticsearch url

### DIFF
--- a/templates/kibana-ingress.yaml
+++ b/templates/kibana-ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.kibana.ingress.enabled -}}
 {{- $serviceName := printf "%s-kibana" (include "fullname" .) -}}
+{{- $servicePort := .Values.kibana.httpPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -22,7 +23,7 @@ spec:
         paths:
           - backend:
               serviceName: {{ $serviceName }}
-              servicePort: {{ .Values.kibana.httpPort }}
+              servicePort: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.kibana.ingress.tls }}
   tls:

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.kibana.enabled }}
+{{- $elasticsearchServiceName := printf "%s-%s" .Release.Name "elasticsearch" | trunc 63 -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -26,6 +27,8 @@ spec:
         env:
         - name: CLUSTER_NAME
           value: {{ .Values.common.env.CLUSTER_NAME }}
+        - name: ELASTICSEARCH_URL
+          value: http://{{ $elasticsearchServiceName }}:{{ .Values.service.httpPort }}
         {{- range $key, $value :=  .Values.kibana.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -29,11 +29,11 @@ client:
     ES_JAVA_OPTS: "-Xms256m -Xmx256m"
 
 # Data nodes hold the shards that contain the documents you have indexed. Data
-# nodes handle data related operations like CRUD, search, and aggregations. 
-# These operations are I/O-, memory-, and CPU-intensive. It is important to 
+# nodes handle data related operations like CRUD, search, and aggregations.
+# These operations are I/O-, memory-, and CPU-intensive. It is important to
 # monitor these resources and to add more data nodes if they are overloaded.
 #
-# The main benefit of having dedicated data nodes is the separation of the 
+# The main benefit of having dedicated data nodes is the separation of the
 # master and data roles.
 data:
   # This count will depend on your data and computation needs.
@@ -58,8 +58,8 @@ data:
     class: "standard"
 
 # The master node is responsible for lightweight cluster-wide actions such as
-# creating or deleting an index, tracking which nodes are part of the 
-# cluster, and deciding which shards to allocate to which nodes. It is 
+# creating or deleting an index, tracking which nodes are part of the
+# cluster, and deciding which shards to allocate to which nodes. It is
 # important for cluster health to have a stable master node.
 master:
   # Master replica count should be (#clients / 2) + 1, and generally at least 3.
@@ -107,7 +107,6 @@ kibana:
     requests:
       cpu: 100m
   env:
-    SERVER_BASEPATH: "/api/v1/proxy/namespaces/default/services/kibana"
     XPACK_GRAPH_ENABLED: "false"
     XPACK_ML_ENABLED: "false"
     XPACK_REPORTING_ENABLED: "false"

--- a/values.yaml
+++ b/values.yaml
@@ -29,11 +29,11 @@ client:
     ES_JAVA_OPTS: "-Xms256m -Xmx256m"
 
 # Data nodes hold the shards that contain the documents you have indexed. Data
-# nodes handle data related operations like CRUD, search, and aggregations.
-# These operations are I/O-, memory-, and CPU-intensive. It is important to
+# nodes handle data related operations like CRUD, search, and aggregations. 
+# These operations are I/O-, memory-, and CPU-intensive. It is important to 
 # monitor these resources and to add more data nodes if they are overloaded.
 #
-# The main benefit of having dedicated data nodes is the separation of the
+# The main benefit of having dedicated data nodes is the separation of the 
 # master and data roles.
 data:
   # This count will depend on your data and computation needs.
@@ -58,8 +58,8 @@ data:
     class: "standard"
 
 # The master node is responsible for lightweight cluster-wide actions such as
-# creating or deleting an index, tracking which nodes are part of the
-# cluster, and deciding which shards to allocate to which nodes. It is
+# creating or deleting an index, tracking which nodes are part of the 
+# cluster, and deciding which shards to allocate to which nodes. It is 
 # important for cluster health to have a stable master node.
 master:
   # Master replica count should be (#clients / 2) + 1, and generally at least 3.


### PR DESCRIPTION
Adds `ELASTICSEARCH_URL` environment variable to Kibana deployment as helm will append a prefix to the service name. 

Also, removes `SERVER_BASEPATH` as it causes Kibana to return 404 response. 

@clockworksoul if it makes sense for you