### PR TITLE
Add liveness and readiness probes

### DIFF
--- a/templates/es-client.yaml
+++ b/templates/es-client.yaml
@@ -81,6 +81,15 @@ spec:
         - containerPort: 9300
           name: transport
           protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: 9300
+        readinessProbe:
+          httpGet:
+            path: /_cluster/health
+            port: 9200
+          initialDelaySeconds: 20
+          timeoutSeconds: 5
         volumeMounts:
         - name: storage
           mountPath: /data

--- a/templates/es-data.yaml
+++ b/templates/es-data.yaml
@@ -85,6 +85,11 @@ spec:
         - containerPort: 9300
           name: transport
           protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: 9300
+          initialDelaySeconds: 20
+          periodSeconds: 10
         volumeMounts:
         - name: storage
           mountPath: /data

--- a/templates/es-master.yaml
+++ b/templates/es-master.yaml
@@ -78,6 +78,9 @@ spec:
         - containerPort: 9300
           name: transport
           protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: 9300
         volumeMounts:
         - name: storage
           mountPath: /data


### PR DESCRIPTION
Based on https://github.com/pires/kubernetes-elasticsearch-cluster/commit/ad8217efc597e10d183ec5b89ed5fca6666821e5

(valiantly copied from monostream/helm-elasticsearch)