### PR TITLE
Implement stateful support for master node  (resolves #15)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.0.5
+version: 0.1.0
 description: Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:

--- a/templates/es-data.yaml
+++ b/templates/es-data.yaml
@@ -1,5 +1,5 @@
-apiVersion: {{ if .Values.data.stateful.enabled }}apps/v1beta1{{ else }}extensions/v1beta1{{ end }}
-kind: {{ if .Values.data.stateful.enabled }}StatefulSet{{ else }}Deployment{{ end }}
+apiVersion: {{ if .Values.common.stateful.enabled }}apps/v1beta1{{ else }}extensions/v1beta1{{ end }}
+kind: {{ if .Values.common.stateful.enabled }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ template "fullname" . }}-data
   labels:
@@ -10,7 +10,7 @@ metadata:
     component: {{ template "fullname" . }}
     role: data
 spec:
-  {{- if .Values.data.stateful.enabled }}
+  {{- if .Values.common.stateful.enabled }}
   serviceName: {{ template "fullname" . }}-data
   {{- end }}
   replicas: {{ .Values.data.replicas }}
@@ -51,10 +51,10 @@ spec:
       containers:
       - name: es-data
         securityContext:
-          privileged: {{ .Values.data.stateful.enabled }}
+          privileged: {{ .Values.common.stateful.enabled }}
           capabilities:
             add:
-              {{- if .Values.data.stateful.enabled }}
+              {{- if .Values.common.stateful.enabled }}
               - IPC_LOCK
               {{- else }}
               - IPC_LOCK
@@ -93,18 +93,18 @@ spec:
         volumeMounts:
         - name: storage
           mountPath: /data
-      {{- if not .Values.data.stateful.enabled }}
+      {{- if not .Values.common.stateful.enabled }}
       volumes:
         - emptyDir:
             medium: ""
           name: "storage"
       {{- end }}
-  {{- if .Values.data.stateful.enabled }}
+  {{- if .Values.common.stateful.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: storage
       annotations:
-        volume.beta.kubernetes.io/storage-class: {{ .Values.data.stateful.class }}
+        volume.beta.kubernetes.io/storage-class: {{ .Values.common.stateful.class }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/templates/es-master.yaml
+++ b/templates/es-master.yaml
@@ -1,5 +1,5 @@
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: {{ if .Values.common.stateful.enabled }}apps/v1beta1{{ else }}extensions/v1beta1{{ end }}
+kind: {{ if .Values.common.stateful.enabled }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ template "fullname" . }}-master
   labels:
@@ -10,6 +10,9 @@ metadata:
     component: {{ template "fullname" . }}
     role: master
 spec:
+  {{- if .Values.common.stateful.enabled }}
+  serviceName: {{ template "fullname" . }}-master
+  {{- end }}
   replicas: {{ .Values.master.replicas }}
   template:
     metadata:
@@ -48,11 +51,15 @@ spec:
       containers:
       - name: es-master
         securityContext:
-          privileged: false
+          privileged: {{ .Values.common.stateful.enabled }}
           capabilities:
             add:
+              {{- if .Values.common.stateful.enabled }}
+              - IPC_LOCK
+              {{- else }}
               - IPC_LOCK
               - SYS_RESOURCE
+              {{- end }}
         image: "{{ .Values.common.image.repository }}:{{ .Values.common.image.tag }}"
         imagePullPolicy: {{ .Values.common.image.pullPolicy }}
         env:
@@ -84,7 +91,21 @@ spec:
         volumeMounts:
         - name: storage
           mountPath: /data
+      {{- if not .Values.common.stateful.enabled }}
       volumes:
         - emptyDir:
             medium: ""
           name: "storage"
+      {{- end }}
+  {{- if .Values.common.stateful.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: storage
+      annotations:
+        volume.beta.kubernetes.io/storage-class: {{ .Values.common.stateful.class }}
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.master.stateful.size }}
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -59,7 +59,8 @@ data:
   # data node StatefulSet that is created when the common.stateful.enabled
   # attribute is true.
   stateful:
-    # This will fill quickly in production. You will want to increase it.
+    # This is a default value, and will not be sufficient in a production
+    # system. You'll probably want to increase it.
     size: 12Gi
 
 # The master node is responsible for lightweight cluster-wide actions such as
@@ -86,8 +87,9 @@ master:
   # data node StatefulSet that is created when the common.stateful.enabled
   # attribute is true.
   stateful:
-    # This will fill quickly in production. You will want to increase it.
-    size: 8Gi
+    # This is a default value, and will not be sufficient in a production
+    # system. You'll probably want to increase it.
+    size: 2Gi
 
 curator:
   enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,15 @@ common:
     # addresses" error.
     # NETWORK_HOST: "_eth0_"
 
+  # If enabled, then the data and master nodes will be StatefulSets with
+  # associated persistent volume claims.
+  stateful:
+    enabled: false
+
+    # The PVC storage class that backs the persistent volume claims. On AWS
+    # "gp2" would be appropriate.
+    class: "standard"
+
 # Client/ingest nodes can execute pre-processing pipelines, composed of
 # one or more ingest processors. Depending on the type of operations performed
 # by the ingest processors and the required resources, it may make sense to
@@ -46,16 +55,12 @@ data:
     HTTP_ENABLE: "false"
     ES_JAVA_OPTS: "-Xms256m -Xmx256m"
 
-  # If enabled, then the data nodes will be StatefulSets with associated
-  # persistent volume claims.
+  # Determines the properties of the persistent volume claim associated with a
+  # data node StatefulSet that is created when the common.stateful.enabled
+  # attribute is true.
   stateful:
-    enabled: false
-
     # This will fill quickly in production. You will want to increase it.
     size: 12Gi
-
-    # The PVC storage class. On AWS "gp2" would be appropriate.
-    class: "standard"
 
 # The master node is responsible for lightweight cluster-wide actions such as
 # creating or deleting an index, tracking which nodes are part of the 
@@ -76,6 +81,13 @@ master:
     # will need a minimum of 2 master nodes to operate. If you have 3 masters
     # and one dies, the cluster still works.
     NUMBER_OF_MASTERS: "2"
+
+  # Determines the properties of the persistent volume claim associated with a
+  # data node StatefulSet that is created when the common.stateful.enabled
+  # attribute is true.
+  stateful:
+    # This will fill quickly in production. You will want to increase it.
+    size: 8Gi
 
 curator:
   enabled: true


### PR DESCRIPTION
This change implements stateful support for master nodes as requested in issue https://github.com/clockworksoul/helm-elasticsearch/issues/15.

Changes include:
- `.Values.data.stateful.enabled` and `.Values.data.stateful.class` attributes have been moved to `.Values.common.stateful`
- `templates/es-data.yaml` logic has been adjusted to account for above point
- `templates/es-master.yaml` updated to include the same `StatefulSet` logic as `templates/es-data.yaml`
- `Chart.yaml` version bumped from `0.0.5` to `0.1.0`. We don't have any defined rules around how out versioning will work, but the changes to `values.yaml` made a minor version bump seem appropriate.

NOTE: I set the default master node volume to 8Gi. Does this make sense? I'm not sure how much space the master node metadata requires even in large production systems, and I'd like the comments in the values file to describe that. 