### PR TITLE
Add a values to set both JVM heap and memory resource request

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: elasticsearch
 home: https://www.elastic.co/products/elasticsearch
-version: 0.1.0
+version: 0.2.0
 description: Elasticsearch is a distributed, RESTful search and analytics engine capable of solving a growing number of use cases.
 icon: https://static-www.elastic.co/assets/blteb1c97719574938d/logo-elastic-elasticsearch-lt.svg
 sources:

--- a/templates/es-client.yaml
+++ b/templates/es-client.yaml
@@ -66,6 +66,8 @@ spec:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
           value: {{ template "fullname" . }}-discovery
+        - name: ES_JAVA_OPTS
+          value: "-Xms{{ .Values.client.requests.memory | default "256m" | lower }} -Xmx{{ .Values.client.requests.memory | default "256m" | lower }}"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
@@ -74,6 +76,9 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
+        resources:
+          requests:
+            memory: {{ .Values.client.requests.memory | default "256m" | upper }}
         ports:
         - containerPort: 9200
           name: http

--- a/templates/es-client.yaml
+++ b/templates/es-client.yaml
@@ -67,7 +67,7 @@ spec:
         - name: DISCOVERY_SERVICE
           value: {{ template "fullname" . }}-discovery
         - name: ES_JAVA_OPTS
-          value: "-Xms{{ .Values.client.requests.memory | default "256m" | lower }} -Xmx{{ .Values.client.requests.memory | default "256m" | lower }}"
+          value: "-Xms{{ .Values.client.heapMemory }} -Xmx{{ .Values.client.heapMemory }}"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
@@ -77,8 +77,7 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         resources:
-          requests:
-            memory: {{ .Values.client.requests.memory | default "256m" | upper }}
+{{ toYaml .Values.client.resources | indent 10 }}
         ports:
         - containerPort: 9200
           name: http

--- a/templates/es-data.yaml
+++ b/templates/es-data.yaml
@@ -74,7 +74,7 @@ spec:
         - name: DISCOVERY_SERVICE
           value: {{ template "fullname" . }}-discovery
         - name: ES_JAVA_OPTS
-          value: "-Xms{{ .Values.data.requests.memory | default "256m" | lower }} -Xmx{{ .Values.data.requests.memory | default "256m" | lower }}"
+          value: "-Xms{{ .Values.data.heapMemory }} -Xmx{{ .Values.data.heapMemory }}"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
@@ -84,8 +84,7 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         resources:
-          requests:
-            memory: {{ .Values.data.requests.memory | default "256m" | upper }}
+{{ toYaml .Values.data.resources | indent 10 }}
         ports:
         - containerPort: 9300
           name: transport

--- a/templates/es-data.yaml
+++ b/templates/es-data.yaml
@@ -73,6 +73,8 @@ spec:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
           value: {{ template "fullname" . }}-discovery
+        - name: ES_JAVA_OPTS
+          value: "-Xms{{ .Values.data.requests.memory | default "256m" | lower }} -Xmx{{ .Values.data.requests.memory | default "256m" | lower }}"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
@@ -81,6 +83,9 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
+        resources:
+          requests:
+            memory: {{ .Values.data.requests.memory | default "256m" | upper }}
         ports:
         - containerPort: 9300
           name: transport

--- a/templates/es-master.yaml
+++ b/templates/es-master.yaml
@@ -74,7 +74,7 @@ spec:
         - name: DISCOVERY_SERVICE
           value: {{ template "fullname" . }}-discovery
         - name: ES_JAVA_OPTS
-          value: "-Xms{{ .Values.master.requests.memory | default "256m" | lower }} -Xmx{{ .Values.master.requests.memory | default "256m" | lower }}"
+          value: "-Xms{{ .Values.master.heapMemory }} -Xmx{{ .Values.master.heapMemory }}"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
@@ -84,8 +84,7 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         resources:
-          requests:
-            memory: {{ .Values.master.requests.memory | default "256m" | upper }}
+{{ toYaml .Values.master.resources | indent 10 }}
         ports:
         - containerPort: 9300
           name: transport

--- a/templates/es-master.yaml
+++ b/templates/es-master.yaml
@@ -73,6 +73,8 @@ spec:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
           value: {{ template "fullname" . }}-discovery
+        - name: ES_JAVA_OPTS
+          value: "-Xms{{ .Values.master.requests.memory | default "256m" | lower }} -Xmx{{ .Values.master.requests.memory | default "256m" | lower }}"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
@@ -81,6 +83,9 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
+        resources:
+          requests:
+            memory: {{ .Values.master.requests.memory | default "256m" | upper }}
         ports:
         - containerPort: 9300
           name: transport

--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,7 @@ common:
 
   env:
     CLUSTER_NAME: "myesdb"
+
     # Uncomment this if you get the "No up-and-running site-local (private)
     # addresses" error.
     # NETWORK_HOST: "_eth0_"
@@ -30,12 +31,17 @@ client:
   # It isn't common to need more than 2 client nodes.
   replicas: 2
   antiAffinity: "soft"
+
+  requests:
+    # Specifies the memory requested for the JVM heap.
+    # Requires a decimal unit (M = 1000^2 bytes, G = 1000^3 bytes).
+    memory: 256M
+
   env:
     NODE_DATA: "false"
     NODE_MASTER: "false"
     NODE_INGEST: "true"
     HTTP_ENABLE: "true"
-    ES_JAVA_OPTS: "-Xms256m -Xmx256m"
 
 # Data nodes hold the shards that contain the documents you have indexed. Data
 # nodes handle data related operations like CRUD, search, and aggregations. 
@@ -48,12 +54,17 @@ data:
   # This count will depend on your data and computation needs.
   replicas: 2
   antiAffinity: "soft"
+
+  requests:
+    # Specifies the memory requested for the JVM heap.
+    # Requires a decimal unit (M = 1000^2 bytes, G = 1000^3 bytes).
+    memory: 256M
+
   env:
     NODE_DATA: "true"
     NODE_MASTER: "false"
     NODE_INGEST: "false"
     HTTP_ENABLE: "false"
-    ES_JAVA_OPTS: "-Xms256m -Xmx256m"
 
   # Determines the properties of the persistent volume claim associated with a
   # data node StatefulSet that is created when the common.stateful.enabled
@@ -71,12 +82,17 @@ master:
   # Master replica count should be (#clients / 2) + 1, and generally at least 3.
   replicas: 3
   antiAffinity: "soft"
+
+  requests:
+    # Specifies the memory requested for the JVM heap.
+    # Requires a decimal unit (M = 1000^2 bytes, G = 1000^3 bytes).
+    memory: 256M
+
   env:
     NODE_DATA: "false"
     NODE_MASTER: "true"
     NODE_INGEST: "false"
     HTTP_ENABLE: "false"
-    ES_JAVA_OPTS: "-Xms256m -Xmx256m"
 
     # The default value for this environment variable is 2, meaning a cluster
     # will need a minimum of 2 master nodes to operate. If you have 3 masters

--- a/values.yaml
+++ b/values.yaml
@@ -33,8 +33,8 @@ client:
   antiAffinity: "soft"
 
   # The amount of RAM allocated to the JVM heap. This should be set to the
-  # same value as resources.requests.memory, or you may see OutOfMemoryErrors
-  # on startup.
+  # same value as client.resources.requests.memory, or you may see
+  # OutOfMemoryErrors on startup.
   heapMemory: 256m
 
   resources:
@@ -60,8 +60,8 @@ data:
   antiAffinity: "soft"
 
   # The amount of RAM allocated to the JVM heap. This should be set to the
-  # same value as resources.requests.memory, or you may see OutOfMemoryErrors
-  # on startup.
+  # same value as data.esources.requests.memory, or you may see
+  # OutOfMemoryErrors on startup.
   heapMemory: 256m
 
   resources:
@@ -92,8 +92,8 @@ master:
   antiAffinity: "soft"
 
   # The amount of RAM allocated to the JVM heap. This should be set to the
-  # same value as resources.requests.memory, or you may see OutOfMemoryErrors
-  # on startup.
+  # same value as master.resources.requests.memory, or you may see
+  # OutOfMemoryErrors on startup.
   heapMemory: 256m
 
   resources:

--- a/values.yaml
+++ b/values.yaml
@@ -32,10 +32,14 @@ client:
   replicas: 2
   antiAffinity: "soft"
 
-  requests:
-    # Specifies the memory requested for the JVM heap.
-    # Requires a decimal unit (M = 1000^2 bytes, G = 1000^3 bytes).
-    memory: 256M
+  # The amount of RAM allocated to the JVM heap. This should be set to the
+  # same value as resources.requests.memory, or you may see OutOfMemoryErrors
+  # on startup.
+  heapMemory: 256m
+
+  resources:
+    requests:
+      memory: 256Mi
 
   env:
     NODE_DATA: "false"
@@ -55,10 +59,14 @@ data:
   replicas: 2
   antiAffinity: "soft"
 
-  requests:
-    # Specifies the memory requested for the JVM heap.
-    # Requires a decimal unit (M = 1000^2 bytes, G = 1000^3 bytes).
-    memory: 256M
+  # The amount of RAM allocated to the JVM heap. This should be set to the
+  # same value as resources.requests.memory, or you may see OutOfMemoryErrors
+  # on startup.
+  heapMemory: 256m
+
+  resources:
+    requests:
+      memory: 256Mi
 
   env:
     NODE_DATA: "true"
@@ -83,10 +91,14 @@ master:
   replicas: 3
   antiAffinity: "soft"
 
-  requests:
-    # Specifies the memory requested for the JVM heap.
-    # Requires a decimal unit (M = 1000^2 bytes, G = 1000^3 bytes).
-    memory: 256M
+  # The amount of RAM allocated to the JVM heap. This should be set to the
+  # same value as resources.requests.memory, or you may see OutOfMemoryErrors
+  # on startup.
+  heapMemory: 256m
+
+  resources:
+    requests:
+      memory: 256Mi
 
   env:
     NODE_DATA: "false"


### PR DESCRIPTION
Currently memory allocation is defined exclusively using the ES_JAVA_OPTS env property, which on memory constrained systems can lead to crash looping as pods are scheduled onto nodes with less available memory than specified in the JVM options, causing a swift and sometimes vague crash due to insufficient memory (issue https://github.com/clockworksoul/helm-elasticsearch/issues/28).

This PR defines a values setting that jointly defines both the `ES_JAVA_OPTS` property and a resource request value

values.yaml:
```
  requests:
    # Specifies the memory requested for the JVM heap.
    # Requires a decimal unit (M = 1000^2 bytes, G = 1000^3 bytes).
    memory: 256M
```

Templates:
```
env:
  - name: ES_JAVA_OPTS
  value: "-Xms{{ .Values.data.requests.memory | default "256m" | lower }} -Xmx{{ .Values.data.requests.memory | default "256m" | lower }}"
```

and

```
resources:
  requests:
    memory: {{ .Values.data.requests.memory | default "256m" | upper }}
```

