### PR TITLE
Switch from init container to continuous running sysctl

### DIFF
--- a/templates/es-client.yaml
+++ b/templates/es-client.yaml
@@ -38,14 +38,23 @@ spec:
                   component: {{ template "fullname" . }}
                   role: client
       {{- end }}
-      initContainers:
-      - name: init-sysctl
-        image: "{{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}"
+      containers:
+      - name: sysctl-conf
+        command:
+        - sh
+        - -c
+        - sysctl -w vm.max_map_count=262166 && while true; do sleep 86400; done
+        image: {{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}
         imagePullPolicy: {{ .Values.image.init.pullPolicy }}
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 50Mi
         securityContext:
           privileged: true
-      containers:
       - name: es-client
         securityContext:
           privileged: false

--- a/templates/es-data.yaml
+++ b/templates/es-data.yaml
@@ -41,14 +41,23 @@ spec:
                   component: {{ template "fullname" . }}
                   role: data
       {{- end }}
-      initContainers:
-      - name: init-sysctl
-        image: "{{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}"
+      containers:
+      - name: sysctl-conf
+        command:
+        - sh
+        - -c
+        - sysctl -w vm.max_map_count=262166 && while true; do sleep 86400; done
+        image: {{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}
         imagePullPolicy: {{ .Values.image.init.pullPolicy }}
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 50Mi
         securityContext:
           privileged: true
-      containers:
       - name: es-data
         securityContext:
           privileged: {{ .Values.common.stateful.enabled }}

--- a/templates/es-master.yaml
+++ b/templates/es-master.yaml
@@ -41,14 +41,23 @@ spec:
                   component: {{ template "fullname" . }}
                   role: master
       {{- end }}
-      initContainers:
-      - name: init-sysctl
-        image: "{{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}"
+      containers:
+      - name: sysctl-conf
+        command:
+        - sh
+        - -c
+        - sysctl -w vm.max_map_count=262166 && while true; do sleep 86400; done
+        image: {{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}
         imagePullPolicy: {{ .Values.image.init.pullPolicy }}
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 50Mi
         securityContext:
           privileged: true
-      containers:
       - name: es-master
         securityContext:
           privileged: {{ .Values.common.stateful.enabled }}


### PR DESCRIPTION
When the pod restarts, the init container is not always executed, leaving a non-functional es instance