### PR TITLE
Add Fluentd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-# for osx
-.DS_Store
+.idea/

--- a/templates/es-svc-external.yaml
+++ b/templates/es-svc-external.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.client.serviceType.external.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    component: {{ template "fullname" . }}
+    role: client
+spec:
+  type: {{ .Values.client.serviceType.external.value }}
+  selector:
+    component: {{ template "fullname" . }}
+    role: client
+  ports:
+  - name: http
+    port: {{ .Values.service.httpPort }}
+    targetPort: 9200
+    protocol: TCP
+  - name: transport
+    port: {{ .Values.service.transportPort }}
+    targetPort: 9300
+    protocol: TCP
+{{- end }}

--- a/templates/es-svc-external.yaml
+++ b/templates/es-svc-external.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}{{ .Values.client.serviceType.external.suffix }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/templates/es-svc-internal.yaml
+++ b/templates/es-svc-internal.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.client.serviceType.internal.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-ingest
+  name: {{ template "fullname" . }}{{ .Values.client.serviceType.internal.suffix }}
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -24,4 +23,3 @@ spec:
     port: {{ .Values.service.transportPort }}
     targetPort: 9300
     protocol: TCP
-{{- end }}

--- a/templates/es-svc-internal.yaml
+++ b/templates/es-svc-internal.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.client.serviceType.internal.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-ingest
   labels:
     app: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -10,7 +11,7 @@ metadata:
     component: {{ template "fullname" . }}
     role: client
 spec:
-  type: {{ .Values.common.serviceType }}
+  type: {{ .Values.client.serviceType.internal.value }}
   selector:
     component: {{ template "fullname" . }}
     role: client
@@ -23,3 +24,4 @@ spec:
     port: {{ .Values.service.transportPort }}
     targetPort: 9300
     protocol: TCP
+{{- end }}

--- a/templates/fluentd-ds.yaml
+++ b/templates/fluentd-ds.yaml
@@ -30,7 +30,7 @@ spec:
         image: {{ .Values.image.fluentd.repository }}:{{ .Values.image.fluentd.tag }}
         env:
           - name:  FLUENT_ELASTICSEARCH_HOST
-            value: '{{ template "fullname" . }}-ingest.{{ .Release.Namespace }}.svc.cluster.local'
+            value: '{{ template "fullname" . }}{{ .Values.client.serviceType.internal.suffix }}.{{ .Release.Namespace }}.svc.cluster.local'
           - name:  FLUENT_ELASTICSEARCH_PORT
             value: "{{ .Values.service.httpPort }}"
           - name: FLUENT_ELASTICSEARCH_SCHEME

--- a/templates/fluentd-ds.yaml
+++ b/templates/fluentd-ds.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.kibana.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "fullname" . }}-fluentd
+  namespace: {{ .Values.fluentd.namespace }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ template "fullname" . }}-fluentd
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      component: {{ template "fullname" . }}-fluentd
+  template:
+    metadata:
+      labels:
+        component: {{ template "fullname" . }}-fluentd
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: fluentd
+        image: {{ .Values.image.fluentd.repository }}:{{ .Values.image.fluentd.tag }}
+        env:
+          - name:  FLUENT_ELASTICSEARCH_HOST
+            value: '{{ template "fullname" . }}'
+          - name:  FLUENT_ELASTICSEARCH_PORT
+            value: "{{ .Values.service.httpPort }}"
+          - name: FLUENT_ELASTICSEARCH_SCHEME
+            value: "{{ .Values.service.httpScheme }}"
+          {{- range $key, $value :=  .Values.fluentd.env }}
+          - name: {{ $key }}
+            value: "{{ $value | quote }}"
+          {{- end }}
+        resources:
+{{ toYaml .Values.fluentd.resources | indent 12 }}
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+{{- end }}

--- a/templates/fluentd-ds.yaml
+++ b/templates/fluentd-ds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kibana.enabled }}
+{{- if .Values.fluentd.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/templates/fluentd-ds.yaml
+++ b/templates/fluentd-ds.yaml
@@ -3,7 +3,9 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "fullname" . }}-fluentd
+{{- if .Values.fluentd.namespace }}
   namespace: {{ .Values.fluentd.namespace }}
+{{- end }}
   labels:
     app: {{ template "fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
@@ -28,7 +30,7 @@ spec:
         image: {{ .Values.image.fluentd.repository }}:{{ .Values.image.fluentd.tag }}
         env:
           - name:  FLUENT_ELASTICSEARCH_HOST
-            value: '{{ template "fullname" . }}'
+            value: '{{ template "fullname" . }}-ingest.{{ .Release.Namespace }}.svc.cluster.local'
           - name:  FLUENT_ELASTICSEARCH_PORT
             value: "{{ .Values.service.httpPort }}"
           - name: FLUENT_ELASTICSEARCH_SCHEME

--- a/templates/kibana-svc.yaml
+++ b/templates/kibana-svc.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
     component: {{ template "fullname" . }}-kibana
 spec:
-  type: {{ .Values.common.serviceType }}
+  type: {{ .Values.kibana.serviceType }}
   ports:
   - port: {{ .Values.kibana.httpPort }}
     targetPort: 5601

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.kibana.enabled }}
-{{- $elasticsearchServiceName := printf "%s-%s" .Release.Name "elasticsearch" | trunc 63 -}}
+{{- $suffix := .Values.client.serviceType.internal.suffix }}
+{{- $elasticsearchServiceName := printf "%s-%s%s" .Release.Name "elasticsearch" $suffix | trunc 63 -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -189,7 +189,7 @@ kibana:
       #     - kibana.local
 
 fluentd:
-  enabled: true
+  enabled: false
   namespace: "kube-system"
   resources:
     limits:

--- a/values.yaml
+++ b/values.yaml
@@ -11,6 +11,10 @@ image:
     repository: bobrik/curator
     tag: latest
     pullPolicy: IfNotPresent
+  fluentd:
+    repository: fluent/fluentd-kubernetes-daemonset
+    tag: v0.12-debian-elasticsearch
+    pullPolicy: IfNotPresent
 
 common:
   # Defines the service type for all outward-facing (non-discovery) services.
@@ -142,6 +146,7 @@ curator:
     unit_count: 3
 
 service:
+  httpScheme: "http"
   httpPort: 9200
   transportPort: 9300
 
@@ -176,4 +181,17 @@ kibana:
       # - secretName: kibana-tls
       #   hosts:
       #     - kibana.local
-      
+
+fluentd:
+  enabled: true
+  namespace: "kube-system"
+  resources:
+    limits:
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  env:
+    # X-Pack Authentication
+    # FLUENT_ELASTICSEARCH_USER: "elastic"
+    # FLUENT_ELASTICSEARCH_PASSWORD: "changeme"

--- a/values.yaml
+++ b/values.yaml
@@ -43,11 +43,12 @@ client:
   antiAffinity: "soft"
   serviceType:
     internal:
-     enabled: true
      value: ClusterIP
+     suffix: "-api"
     external:
       enabled: false
       value: LoadBalancer # or NodePort if using minikube
+      suffix: ""
 
   # The amount of RAM allocated to the JVM heap. This should be set to the
   # same value as client.resources.requests.memory, or you may see

--- a/values.yaml
+++ b/values.yaml
@@ -1,8 +1,8 @@
 image:
   es:
     repository: quay.io/pires/docker-elasticsearch-kubernetes
-    tag: 6.0.0
-    pullPolicy: Always
+    tag: 6.1.3
+    pullPolicy: IfNotPresent
   init:
     repository: busybox
     tag: latest
@@ -13,14 +13,10 @@ image:
     pullPolicy: IfNotPresent
   fluentd:
     repository: fluent/fluentd-kubernetes-daemonset
-    tag: v0.12-debian-elasticsearch
+    tag: v0.12-alpine-elasticsearch
     pullPolicy: IfNotPresent
 
 common:
-  # Defines the service type for all outward-facing (non-discovery) services.
-  # For minikube use NodePort otherwise use LoadBalancer
-  serviceType: LoadBalancer
-
   env:
     CLUSTER_NAME: "myesdb"
 
@@ -45,6 +41,13 @@ client:
   # It isn't common to need more than 2 client nodes.
   replicas: 2
   antiAffinity: "soft"
+  serviceType:
+    internal:
+     enabled: true
+     value: ClusterIP
+    external:
+      enabled: false
+      value: LoadBalancer # or NodePort if using minikube
 
   # The amount of RAM allocated to the JVM heap. This should be set to the
   # same value as client.resources.requests.memory, or you may see
@@ -168,6 +171,8 @@ kibana:
     # XPACK_ML_ENABLED: "false"
     # XPACK_REPORTING_ENABLED: "false"
     # XPACK_SECURITY_ENABLED: "false"
+  # Pay attention to serviceType v. ingress.
+  serviceType: LoadBalancer
   ingress:
     enabled: false
     # Used to create an Ingress record.


### PR DESCRIPTION
*****************************************************************************************
* https://github.com/clockworksoul/helm-elasticsearch/blob/docs/contributing-guide/CONTRIBUTING.md#technical-requirements ✅
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices ✅
*****************************************************************************************
This PR fixes #44 allows the user to opt-in to using Fluentd.  It's based on https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/fluentd-daemonset-elasticsearch.yaml.
