### PR TITLE
Support for node scheduling using nodeSelector and traints

### DIFF
--- a/templates/es-client.yaml
+++ b/templates/es-client.yaml
@@ -38,6 +38,16 @@ spec:
                   component: {{ template "fullname" . }}
                   role: client
       {{- end }}
+
+    {{- if .Values.client.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.client.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.client.tolerations }}
+      tolerations:
+{{ toYaml .Values.client.tolerations | indent 8 }}
+    {{- end }}
+
       initContainers:
       - name: init-sysctl
         image: "{{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}"

--- a/templates/es-data.yaml
+++ b/templates/es-data.yaml
@@ -41,6 +41,16 @@ spec:
                   component: {{ template "fullname" . }}
                   role: data
       {{- end }}
+
+    {{- if .Values.data.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.data.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.data.tolerations }}
+      tolerations:
+{{ toYaml .Values.data.tolerations | indent 8 }}
+    {{- end }}
+
       initContainers:
       - name: init-sysctl
         image: "{{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}"

--- a/templates/es-master.yaml
+++ b/templates/es-master.yaml
@@ -41,6 +41,16 @@ spec:
                   component: {{ template "fullname" . }}
                   role: master
       {{- end }}
+
+    {{- if .Values.master.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.master.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.master.tolerations }}
+      tolerations:
+{{ toYaml .Values.master.tolerations | indent 8 }}
+    {{- end }}
+
       initContainers:
       - name: init-sysctl
         image: "{{ .Values.image.init.repository }}:{{ .Values.image.init.tag }}"

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -20,6 +20,15 @@ spec:
       labels:
         component: {{ template "fullname" . }}-kibana
     spec:
+    {{- if .Values.kibana.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.kibana.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.kibana.tolerations }}
+      tolerations:
+{{ toYaml .Values.kibana.tolerations | indent 8 }}
+    {{- end }}
+
       containers:
       - name: kibana
         image: "{{ .Values.kibana.image.repository }}:{{ .Values.kibana.image.tag }}"

--- a/values.yaml
+++ b/values.yaml
@@ -57,6 +57,20 @@ client:
     NODE_INGEST: "true"
     HTTP_ENABLE: "true"
 
+  ## Node tolerations for client scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+    # - key: "key"
+    #   operator: "Equal|Exists"
+    #   value: "value"
+    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  ## Node labels for client pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+
 # Data nodes hold the shards that contain the documents you have indexed. Data
 # nodes handle data related operations like CRUD, search, and aggregations. 
 # These operations are I/O-, memory-, and CPU-intensive. It is important to 
@@ -91,6 +105,20 @@ data:
     # This is a default value, and will not be sufficient in a production
     # system. You'll probably want to increase it.
     size: 12Gi
+
+  ## Node tolerations for data scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+    # - key: "key"
+    #   operator: "Equal|Exists"
+    #   value: "value"
+    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  ## Node labels for data pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
 
 # The master node is responsible for lightweight cluster-wide actions such as
 # creating or deleting an index, tracking which nodes are part of the 
@@ -128,6 +156,20 @@ master:
     # This is a default value, and will not be sufficient in a production
     # system. You'll probably want to increase it.
     size: 2Gi  
+
+  ## Node tolerations for master scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+    # - key: "key"
+    #   operator: "Equal|Exists"
+    #   value: "value"
+    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  ## Node labels for master pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
 
 curator:
   enabled: true


### PR DESCRIPTION
In production deployments, sometimes it becomes critical to be able to scheduling deployments to selected nodes.

Adding support for taints and nodeSelector helps us to achieve this.