### PR TITLE
Add close action support for curator

### DIFF
--- a/templates/es-curator-config.yaml
+++ b/templates/es-curator-config.yaml
@@ -25,6 +25,7 @@ data:
           timeout_override:
           continue_if_exception: False
           disable_action: False
+          ignore_empty_list: {{ .Values.curator.options.ignoreEmptyList }}
         filters:
         - filtertype: age
           source: name
@@ -36,6 +37,25 @@ data:
           stats_result:
           epoch:
           exclude: False
+      2:
+        action: close
+        description: Close old indices
+        options:
+          delete_aliases: False
+          disable_action: {{ .Values.curator.close.disabled }}
+          ignore_empty_list: {{ .Values.curator.options.ignoreEmptyList }}
+        filters:
+        - filtertype: age
+          source: name
+          direction: older
+          timestring: '{{ .Values.curator.close.age.timestring }}'
+          unit: {{ .Values.curator.close.age.unit }}
+          unit_count: {{ .Values.curator.close.age.unit_count }}
+          field:
+          stats_result:
+          epoch:
+          exclude: False
+
   config.yml: |-
     ---
     # Remember, leave a key empty if there is no value.  None will be a string,

--- a/values.yaml
+++ b/values.yaml
@@ -133,6 +133,9 @@ curator:
   enabled: true
   schedule: "0 1 * * *"
 
+  options:
+    ignoreEmptyList: "True"
+
   # Allows modification of the default age-based filter. If you require more
   # sophisticated filtering, modify the action file specified in
   # templates/es-curator-config.yaml.
@@ -140,6 +143,14 @@ curator:
     timestring: "%Y.%m.%d"
     unit: "days"
     unit_count: 3
+
+  # Enables close action based on age based filter
+  close:
+    disabled: "True"
+    age:
+      timestring: "%Y.%m.%d"
+      unit: "days"
+      unit_count: 3
 
 service:
   httpPort: 9200


### PR DESCRIPTION
Closing older indices can help us improve overall cluster performance especially in logging environment.
