### PR TITLE
Add annotations support for service

### DIFF
--- a/templates/es-svc.yaml
+++ b/templates/es-svc.yaml
@@ -9,6 +9,10 @@ metadata:
     heritage: "{{ .Release.Service }}"
     component: {{ template "fullname" . }}
     role: client
+{{ if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{ end }}
 spec:
   type: {{ .Values.common.serviceType }}
   selector:


### PR DESCRIPTION
Allow users to pass annotations for the data service.

One use case is, if we want add some plugins like [Prometheus Exporter](https://github.com/vvanholl/elasticsearch-prometheus-exporter) and have to enable service discovery, then we need to pass some custom annotations to the service.

It makes much sense to expand the service definition to accept the annotations than having to create custom definitions
